### PR TITLE
fix: log format

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -40,24 +40,24 @@ func PrintTextWithColor(file *os.File, callback func(Colors) string) {
 
 func PrintInfo(text string) {
 	PrintTextWithColor(os.Stdout, func(c Colors) string {
-		return fmt.Sprintf("%s%s%s", c.Blue, text, c.Reset)
+		return fmt.Sprintf("%s%s%s\n", c.Blue, text, c.Reset)
 	})
 }
 
 func PrintError(text string) {
 	PrintTextWithColor(os.Stderr, func(c Colors) string {
-		return fmt.Sprintf("%s%s%s", c.Red, text, c.Reset)
+		return fmt.Sprintf("%s%s%s\n", c.Red, text, c.Reset)
 	})
 }
 
 func PrintSuccess(text string) {
 	PrintTextWithColor(os.Stdout, func(c Colors) string {
-		return fmt.Sprintf("%s%s%s", c.Green, text, c.Reset)
+		return fmt.Sprintf("%s%s%s\n", c.Green, text, c.Reset)
 	})
 }
 
 func PrintWarn(text string) {
 	PrintTextWithColor(os.Stdout, func(c Colors) string {
-		return fmt.Sprintf("%s%s%s", c.Yellow, text, c.Reset)
+		return fmt.Sprintf("%s%s%s\n", c.Yellow, text, c.Reset)
 	})
 }


### PR DESCRIPTION
After printing the log, add a newline character

![image](https://user-images.githubusercontent.com/38528079/166153419-ef12e5b4-64b2-44e8-aa7f-fa230555bfeb.png)
